### PR TITLE
socklen_t on MSVC2010, consistent behaviour on Win32 vs. others

### DIFF
--- a/socketpair.c
+++ b/socketpair.c
@@ -121,12 +121,12 @@ int dumb_socketpair(SOCKET socks[2], int make_overlapped)
 int dumb_socketpair(int socks[2], int dummy)
 {
     if (socks == 0) {
-		errno = EINVAL;
-		return -1;
+        errno = EINVAL;
+        return -1;
     }
     dummy = socketpair(AF_LOCAL, SOCK_STREAM, 0, socks);
-	if (dummy)
-	    socks[0] = socks[1] = -1;
-	return dummy;
+    if (dummy)
+        socks[0] = socks[1] = -1;
+    return dummy;
 }
 #endif


### PR DESCRIPTION
one fix: include corrected so MSVC2010 knows about socklen_t now.

one tweak: always have the socks[] initialized to a 'sane' value (-1 / INVALID_SOCKET) when an error occurs.
Win32 code already did this most of the time (not all cases).
